### PR TITLE
Increased nokogiri dependency to allow 1.11 version

### DIFF
--- a/docxer.gemspec
+++ b/docxer.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir["lib/**/*"] + ["LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency 'nokogiri', '>= 1.6.3', '< 1.7'
+  s.add_dependency 'nokogiri', '>= 1.6.3', '~> 1.11'
   s.add_dependency 'rubyzip', '~> 0.9.9'
 end


### PR DESCRIPTION
I've increased nokogiri version with a pessimistic operator to allow versions between 1.11 and 1.12, cause we've currently installed version 1.11.3.